### PR TITLE
WordPress ESlint settings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,32 +1,3 @@
 {
-  "parser": "babel-eslint",
-  "env": {
-    "browser": true,
-    "es6": true
-  },
-  "extends": "eslint:recommended",
-  "rules": {
-    "yoda": [ 2, "always" ],
-    "indent": [ 2, "tab", { "SwitchCase": 2 } ],
-    "linebreak-style": [ 2, "unix" ],
-    "quotes": [ 2, "single" ],
-    "semi": [ 2, "always" ],
-    "space-in-parens": [ 2, "always" ],
-    "camelcase": [ 2 ],
-    "prefer-template": [ 2 ],
-    "prefer-const": [ 2 ],
-    "prefer-destructuring": [ 1 ],
-    "no-console": [ 1 ],
-    "no-alert": [ 1 ],
-    "no-var": [ 1 ],
-    "require-jsdoc": [ 2, {
-      "require" : {
-        "FunctionDeclaration" : true,
-        "MethodDefinition" : true,
-        "ClassDeclaration" : true,
-        "ArrowFunctionExpression" : true,
-        "FunctionExpression" : true
-      }
-    }]
-  }
+  "extends": [ "plugin:@wordpress/eslint-plugin/recommended" ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@10up/eslint-config",
-  "version": "1.0.9",
+  "version": "2.0.0",
   "description": "A shareable ESLint configuration",
   "main": ".eslintrc",
   "repository": {
@@ -18,8 +18,8 @@
     "eslint-config",
     "10up"
   ],
-  "devDependencies": {
-    "eslint": "^6.5.1"
+  "dependencies": {
+    "@wordpress/eslint-plugin": "^2.4.0"
   },
   "eslintConfig": {
     "extends": "./.eslintrc"


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This fixes: https://github.com/10up/eslint-config/issues/15

### Benefits

The WordPress JS coding standards have changed a lot, particularly after Gutenberg.

Using the recommended JS coding standards will bring development closer to what happens in core.

### Possible Drawbacks

1. Devs will have to get up to speed with the changes, and older projects will need to point to the older version of this config
1. I've referenced version `2.4.0` which is the last version before major [breaking changes](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/CHANGELOG.md). We would need to keep an eye on what happens in core and carefully update it as needed

### Verification Process

Tested this by installing my fork locally and running `eslint test.js`. It picked up the correct coding standards.

`npm install https://github.com/junaidbhura/eslint-config#feature/wp-js-standards --save-dev`

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes: https://github.com/10up/eslint-config/issues/15
Fixes: https://github.com/10up/eslint-config/issues/6
Fixes: https://github.com/10up/eslint-config/issues/11
